### PR TITLE
Fix: 유료 아이템 상품 정보 없음 오류 해결 -> storekit 파일 scheme 연결

### DIFF
--- a/Grruung.xcodeproj/xcshareddata/xcschemes/Grruung.xcscheme
+++ b/Grruung.xcodeproj/xcshareddata/xcschemes/Grruung.xcscheme
@@ -57,7 +57,7 @@
          </CommandLineArgument>
       </CommandLineArguments>
       <StoreKitConfigurationFileReference
-         identifier = "../../Grruung/ShopItems.storekit">
+         identifier = "../../Grruung/ShopItems.storekit/Configuration.storekit/Configuration.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
- storekit파일이 scheme과 연결이 끊어져있었습니다.